### PR TITLE
Detect authentication type

### DIFF
--- a/oauth2_server.c
+++ b/oauth2_server.c
@@ -522,11 +522,18 @@ int oauth2_server_step(void *conn_context, sasl_server_params_t *params,
     char *token = NULL;
     int parse_result;
     
-    /* Try to parse as XOAUTH2 first, then OAUTHBEARER */
-    parse_result = oauth2_parse_xoauth2(utils, clientin, clientinlen, &username, &token);
-    if (parse_result != SASL_OK) {
-        /* If XOAUTH2 parsing fails, try OAUTHBEARER */
+    /* Looks like XOAUTH2 */
+    if (strncmp(clientin, "user=", 5) == 0) {
+        OAUTH2_LOG_INFO(utils, "Trying XOAuth2 authentication");
+        parse_result = oauth2_parse_xoauth2(utils, clientin, clientinlen, &username, &token);
+    /* Looks like OAUTHBEARER */
+    } else if (strncmp(clientin, "n,", 2) == 0) {
+        OAUTH2_LOG_INFO(utils, "Trying OAuthBearer authentication");
         parse_result = oauth2_parse_oauthbearer(clientin, clientinlen, &username, &token);
+    /* Default, try XOAUTH2 */
+    } else {
+        OAUTH2_LOG_INFO(utils, "Trying XOAuth2 authentication as failback");
+        parse_result = oauth2_parse_xoauth2(utils, clientin, clientinlen, &username, &token);
     }
     
     if (parse_result != SASL_OK) {


### PR DESCRIPTION
Instead of trying XOAUTH2 first and fallback to OAUTHBEARER, this proposal tries to detect the used authentication mechanism and calls the corresponding `oauth2_parse_` function.
When using the standardised OAUTHBEARER method, it avoids reporting useless errors.

This proposal also gives the ability to package from AMD64 architecture from an non-AMD64 host.
