### PR TITLE
Extend fallback configuration to read all OAuth2 options

### DIFF
--- a/README.md
+++ b/README.md
@@ -232,7 +232,6 @@ The OAuth2 SASL plugin configuration format **depends on the application** you'r
 | Application Type | Config File Location | Option Format | Example |
 |-----------------|---------------------|---------------|---------|
 | **Cyrus IMAP** | `/etc/imapd.conf` | `sasl_oauth2_*` | `sasl_oauth2_discovery_url: https://...` |
-| **Postfix SMTP** | `/etc/sasl2/smtpd.conf` | `oauth2_*` | `oauth2_discovery_url: https://...` |
 | **Dovecot** | `/etc/sasl2/dovecot.conf` | `oauth2_*` | `oauth2_discovery_url: https://...` |
 | **Sendmail** | `/etc/sasl2/Sendmail.conf` | `oauth2_*` | `oauth2_discovery_url: https://...` |
 
@@ -341,7 +340,7 @@ sasl_oauth2_fallback_config: /etc/sasl2/oauth2.conf
 
 ### Fallback Configuration File
 
-The plugin supports a fallback configuration file that provides default OAuth2 settings when applications don't have their own OAuth2 configuration. This is particularly useful for SASL tools like `saslauthd`, `pluginviewer`, and `imtest` that don't have dedicated configuration files.
+The plugin supports a fallback configuration file that provides default OAuth2 settings when applications don't have their own OAuth2 configuration. This is particularly useful for SASL tools like `saslauthd`, `pluginviewer`, and `imtest` that don't have dedicated configuration files and for applications like Postfix that read only a subset of SASL configurations.
 
 **Default Location**: `/etc/sasl2/oauth2.conf`
 
@@ -485,6 +484,13 @@ sasl_oauth2_audience: your-audience
 
 **⚠️ IMPORTANT**: Postfix uses SASL configuration files **WITHOUT** the `sasl_` prefix.
 
+**⚠️ IMPORTANT**: https://www.postfix.org/SASL_README.html
+                 "This means that some SASL-related configuration files will belong to 
+                  Postfix, while other configuration files belong to the specific SASL 
+                  implementation that Postfix will use."
+
+Oauth2 is a specific SASL implementation and its configuration belongs to /etc/sasl2/oauth2.conf.
+
 ```ini
 # /etc/postfix/main.cf
 smtpd_sasl_auth_enable = yes
@@ -494,12 +500,14 @@ smtpd_sasl_security_options = noanonymous
 smtpd_sasl_local_domain = example.com
 
 # /etc/sasl2/smtpd.conf - SASL plugin configuration (NO sasl_ prefix!)
+mech_list: oauthbearer xoauth2 plain login
+
+# /etc/sasl2/oauth2.conf
 oauth2_discovery_url: https://your-provider.com/.well-known/openid-configuration
 oauth2_client_id: your-smtp-client-id
 oauth2_audience: your-smtp-audience
 oauth2_user_claim: email
 oauth2_scope: openid email profile
-mech_list: oauthbearer xoauth2 plain login
 ```
 
 ### Dovecot Integration

--- a/oauth2_plugin.h
+++ b/oauth2_plugin.h
@@ -93,7 +93,12 @@ typedef struct oauth2_config {
     /* Runtime state */
     oauth2_log_t *oauth2_log;
     int configured;  /* 1 if essential configuration is present, 0 if not */
-    int client_id_allocated;  /* 1 if client_id was allocated (from fallback), 0 if from SASL */
+    
+    /* Allocation tracking for fallback config (to know what to free) */
+    int client_id_allocated;      /* 1 if client_id was allocated (from fallback), 0 if from SASL */
+    int client_secret_allocated;  /* 1 if client_secret was allocated (from fallback), 0 if from SASL */
+    int scope_allocated;          /* 1 if scope was allocated (from fallback), 0 if from SASL */
+    int user_claim_allocated;     /* 1 if user_claim was allocated (from fallback), 0 if from SASL */
 } oauth2_config_t;
 
 /* Function prototypes */


### PR DESCRIPTION
## Problem

The fallback configuration file (`/etc/sasl2/oauth2.conf`) only read 4 basic options:
- `oauth2_discovery_url`
- `oauth2_issuer`
- `oauth2_client_id`
- `oauth2_audience`

This caused authentication failures with Postfix SMTP:
```
warning: SASL authentication failure: oauth2_plugin: User claim 'email' not found or not a string in JWT
```
even with "oauth2_user_claim: sub" put in /etc/sasl2/smtpd.conf, /etc/postfix/sasl/smtpd.conf and /etc/sasl2/oauth2.conf
 
## Root Cause

Postfix's SASL implementation doesn't transmit plugin-specific options via SASL `getopt()`. 
From the [Postfix SASL README](https://www.postfix.org/SASL_README.html):

> "This means that some SASL-related configuration files will belong to Postfix, 
> while other configuration files belong to the specific SASL implementation that Postfix will use."

The fallback configuration mechanism was designed for this scenario but was incomplete.

## Solution

Extended `oauth2_load_fallback_config()` to read **all** OAuth2 configuration options:
- All singular options: `oauth2_user_claim`, `oauth2_client_secret`, `oauth2_scope`, etc.
- Plural forms: `oauth2_discovery_urls`, `oauth2_issuers`, `oauth2_audiences`
- Boolean/integer options: `oauth2_debug`, `oauth2_timeout`, `oauth2_verify_signature`, etc.

## Changes

### Modified Files

1. **`oauth2_plugin.h`**
   - Added allocation tracking fields to `oauth2_config_t` for proper memory management

2. **`oauth2_config.c`**
   - Extended `oauth2_load_fallback_config()` to read all options
   - Modified `oauth2_config_load()` to not override fallback values
   - Modified `oauth2_config_free()` to free fallback-allocated strings
   - Modified `oauth2_config_init()` to initialize sentinel values

3. **`README.md`**
   - Clarified fallback configuration usage
   - Updated Postfix integration section with correct configuration
   - Referenced official Postfix documentation

## Testing

Tested with Postfix SMTP server using `/etc/sasl2/oauth2.conf`:
```ini
oauth2_discovery_url: https://cas.server.fr/oidc/.well-known/openid-configuration
oauth2_client_id: my_client
oauth2_user_claim: sub
oauth2_debug: yes
```

Result:  Authentication successful

## Compatibility

-  Cyrus IMAP: Continues to work (uses SASL getopt())
-  Postfix SMTP: Now works (uses fallback file)
-  Backward compatible with existing configurations

## References

- Postfix SASL README: https://www.postfix.org/SASL_README.html