### PR TITLE
Fix compatibility with liboauth2 >= 2.2.0

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -156,6 +156,39 @@ else
     OAUTH2_LDFLAGS="-L/usr/local/lib"
 fi
 
+# Check liboauth2 API version (oauth2_token_verify signature changed in 2.2.0)
+AC_MSG_CHECKING([whether oauth2_token_verify uses 5 or 6 parameters])
+save_CFLAGS="$CFLAGS"
+save_LIBS="$LIBS"
+CFLAGS="$CFLAGS -I/usr/include -I/usr/local/include"
+LIBS="$LIBS -loauth2 -ljansson"
+
+# Try to compile with 6 parameters (new API >= 2.2.0)
+AC_COMPILE_IFELSE(
+    [AC_LANG_PROGRAM(
+        [[
+#include <oauth2/oauth2.h>
+#include <jansson.h>
+        ]],
+        [[
+oauth2_log_t *log = NULL;
+oauth2_cfg_token_verify_t *verify = NULL;
+const char *token = "test";
+json_t *payload = NULL;
+oauth2_http_status_code_t status = 0;
+(void)oauth2_token_verify(log, NULL, verify, token, &payload, &status);
+        ]])],
+    [
+        AC_MSG_RESULT([6 parameters (liboauth2 >= 2.2.0)])
+    ],
+    [
+        AC_MSG_RESULT([5 parameters (liboauth2 < 2.2.0)])
+	OAUTH2_CPPFLAGS="$OAUTH2_CPPFLAGS -DLIBOAUTH2_OLD_API"
+    ])
+
+CFLAGS="$save_CFLAGS"
+LIBS="$save_LIBS"
+
 AC_SUBST([OAUTH2_CPPFLAGS])
 AC_SUBST([OAUTH2_LDFLAGS])
 

--- a/oauth2_server.c
+++ b/oauth2_server.c
@@ -249,7 +249,18 @@ static int oauth2_validate_jwt_token(const sasl_utils_t *utils,
         
         if (rv == NULL) {
             /* liboauth2 handles caching internally - we don't need to detect it manually */
+            /* Compatibility with liboauth2 1.x (5 params) and 2.x (6 params) API.
+             * We try the new API first, and if it doesn't compile, configure.ac 
+             * will detect it and define LIBOAUTH2_OLD_API for us.
+             */
+#ifdef LIBOAUTH2_OLD_API
+            /* liboauth2 < 2.2.0 - 5 parameters */
             validation_success = oauth2_token_verify(config->oauth2_log, NULL, verify, token, &json_payload);
+#else
+            /* liboauth2 >= 2.2.0 - 6 parameters (added status_code) */
+            oauth2_http_status_code_t status_code = 0;
+            validation_success = oauth2_token_verify(config->oauth2_log, NULL, verify, token, &json_payload, &status_code);
+#endif
             if (validation_success) {
                 OAUTH2_LOG_INFO(utils, "JWT validation successful using metadata discovery");
             } else {


### PR DESCRIPTION
 The oauth2_token_verify() API changed in liboauth2 2.2.0, adding
 a 6th parameter (oauth2_http_status_code_t *status_code).
 .
 This breaks compilation on systems with liboauth2 >= 2.2.0:
 - Debian Unstable (liboauth2 2.2.x)
 - Fedora 41+ (liboauth2 2.x) .
 
 Add compile-time detection in configure.ac to test the function signature and define LIBOAUTH2_OLD_API for older versions.
 
 Compilation successfully tested  on Debian/unstable, Debian/Trixie and Debian/bookworm.