### PR TITLE
Fix liboauth2 API detection for Fedora RPM builds

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -158,9 +158,11 @@ fi
 
 # Check liboauth2 API version (oauth2_token_verify signature changed in 2.2.0)
 AC_MSG_CHECKING([whether oauth2_token_verify uses 5 or 6 parameters])
+save_CPPFLAGS="$CPPFLAGS"
 save_CFLAGS="$CFLAGS"
 save_LIBS="$LIBS"
-CFLAGS="$CFLAGS -I/usr/include -I/usr/local/include"
+CPPFLAGS="$CPPFLAGS $OAUTH2_CPPFLAGS"
+CFLAGS="-c"
 LIBS="$LIBS -loauth2 -ljansson"
 
 # Try to compile with 6 parameters (new API >= 2.2.0)
@@ -171,12 +173,12 @@ AC_COMPILE_IFELSE(
 #include <jansson.h>
         ]],
         [[
-oauth2_log_t *log = NULL;
-oauth2_cfg_token_verify_t *verify = NULL;
+oauth2_log_t *log = (oauth2_log_t *)0;
+oauth2_cfg_token_verify_t *verify = (oauth2_cfg_token_verify_t *)0;
 const char *token = "test";
-json_t *payload = NULL;
-oauth2_http_status_code_t status = 0;
-(void)oauth2_token_verify(log, NULL, verify, token, &payload, &status);
+json_t *payload = (json_t *)0;
+oauth2_http_status_code_t status_code = 0;
+(void)oauth2_token_verify(log, (oauth2_http_request_t *)0, verify, token, &payload, &status_code);
         ]])],
     [
         AC_MSG_RESULT([6 parameters (liboauth2 >= 2.2.0)])
@@ -186,6 +188,7 @@ oauth2_http_status_code_t status = 0;
 	OAUTH2_CPPFLAGS="$OAUTH2_CPPFLAGS -DLIBOAUTH2_OLD_API"
     ])
 
+CPPFLAGS="$save_CPPFLAGS"
 CFLAGS="$save_CFLAGS"
 LIBS="$save_LIBS"
 


### PR DESCRIPTION
## Summary

Fixes the liboauth2 >= 2.2.0 API detection that was introduced in PR #6 but wasn't working correctly on Fedora 41+/43 RPM builds.

The `AC_COMPILE_IFELSE` test in `configure.ac` was failing spuriously because:
- **Hardcoded include paths** (`-I/usr/include -I/usr/local/include`) instead of using the properly set `OAUTH2_CPPFLAGS` variable
- **Fedora RPM strict CFLAGS** (`-Werror=format-security`, `-specs=/usr/lib/rpm/redhat/redhat-annobin-cc1`, etc.) were leaking into the detection test, causing it to fail even when liboauth2 2.2.0 was correctly installed
- **Implicit NULL conversions** in the test code triggered warnings promoted to errors by Fedora's strict compiler flags

This caused the test to incorrectly detect the "old" 5-parameter API, define `LIBOAUTH2_OLD_API`, and then fail at build time with:
```
error: too few arguments to function 'oauth2_token_verify'; expected 6, have 5
```

## Changes
- Use `OAUTH2_CPPFLAGS` for include paths in the detection test
- Reset `CFLAGS` to just `-c` during detection to isolate from RPM build flags
- Use explicit casts in the test program to avoid type warnings
- Properly save/restore `CPPFLAGS`

## Test plan
- [x] Verify Fedora 43 RPM build passes in CI
- [x] Verify Debian build still works (liboauth2 < 2.2.0 path)